### PR TITLE
Update CardForgeMod.java

### DIFF
--- a/src/main/java/com/eternal0/slay/the/spire/mods/CardForgeMod.java
+++ b/src/main/java/com/eternal0/slay/the/spire/mods/CardForgeMod.java
@@ -46,14 +46,7 @@ public class CardForgeMod implements PostCreateStartingRelicsSubscriber, EditRel
         BaseMod.addRelic(new AnvilOfTheGodsRelic(), RelicType.SHARED);
         logger.info("Done adding relics");
     }
-/*
-    public void receivePostDungeonInitialize() {
-        logger.info("reached receivepostdungeoninitialize");
-        RelicLibrary.getRelic(SeethingFireRelic.ID).makeCopy().instantObtain();
-        RelicLibrary.getRelic(HammerOfThorRelic.ID).makeCopy().instantObtain();
-        RelicLibrary.getRelic(AnvilOfTheGodsRelic.ID).makeCopy().instantObtain();
-    }
-*/
+
     public void receivePostCreateStartingRelics(AbstractPlayer.PlayerClass pclass, ArrayList<String> relicslist) {
         logger.info("reached receivepostcreatestartingrelics");
         relicslist.add(HammerOfThorRelic.ID);

--- a/src/main/java/com/eternal0/slay/the/spire/mods/CardForgeMod.java
+++ b/src/main/java/com/eternal0/slay/the/spire/mods/CardForgeMod.java
@@ -6,42 +6,58 @@ import basemod.helpers.RelicType;
 import basemod.interfaces.EditRelicsSubscriber;
 import basemod.interfaces.EditStringsSubscriber;
 import basemod.interfaces.PostDungeonInitializeSubscriber;
+import basemod.interfaces.PostCreateStartingRelicsSubscriber;
+
 import com.badlogic.gdx.Gdx;
 import com.eternal0.slay.the.spire.mods.relics.AnvilOfTheGodsRelic;
 import com.eternal0.slay.the.spire.mods.relics.HammerOfThorRelic;
 import com.eternal0.slay.the.spire.mods.relics.SeethingFireRelic;
 import com.eternal0.slay.the.spire.mods.ui.ScreenManager;
 import com.evacipated.cardcrawl.modthespire.lib.SpireInitializer;
+import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.helpers.RelicLibrary;
 import com.megacrit.cardcrawl.localization.RelicStrings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.ArrayList;
+
 @SpireInitializer
-public class CardForgeMod implements PostDungeonInitializeSubscriber, EditRelicsSubscriber, EditStringsSubscriber {
+public class CardForgeMod implements PostCreateStartingRelicsSubscriber, EditRelicsSubscriber, EditStringsSubscriber {
     private static final Logger logger = LogManager.getLogger(CardForgeMod.class.getName());
 
     public static void initialize() {
+        logger.info("reached initialize");
         BaseMod.subscribe(new CardForgeMod());
         BaseMod.subscribe(ScreenManager.INSTANCE);
     }
 
     public void receiveEditStrings() {
+        logger.info("reached receiveeditstrings");
         final String relicStrings = Gdx.files.internal("localization/RelicStrings.json").readString("UTF-8");
         BaseMod.loadCustomStrings(RelicStrings.class, relicStrings);
     }
 
     public void receiveEditRelics() {
+        logger.info("reached receiveeditrelics");
         logger.info("Adding relics");
         BaseMod.addRelic(new SeethingFireRelic(), RelicType.SHARED);
         BaseMod.addRelic(new HammerOfThorRelic(), RelicType.SHARED);
         BaseMod.addRelic(new AnvilOfTheGodsRelic(), RelicType.SHARED);
         logger.info("Done adding relics");
     }
-
+/*
     public void receivePostDungeonInitialize() {
+        logger.info("reached receivepostdungeoninitialize");
         RelicLibrary.getRelic(SeethingFireRelic.ID).makeCopy().instantObtain();
         RelicLibrary.getRelic(HammerOfThorRelic.ID).makeCopy().instantObtain();
         RelicLibrary.getRelic(AnvilOfTheGodsRelic.ID).makeCopy().instantObtain();
+    }
+*/
+    public void receivePostCreateStartingRelics(AbstractPlayer.PlayerClass pclass, ArrayList<String> relicslist) {
+        logger.info("reached receivepostcreatestartingrelics");
+        relicslist.add(HammerOfThorRelic.ID);
+        relicslist.add(SeethingFireRelic.ID);
+        relicslist.add(AnvilOfTheGodsRelic.ID);
     }
 }


### PR DESCRIPTION
The 2.0 update broke the mod because when the relics would be given (right after dungeon initialization) the relic tutorial popup would happen, causing a crash because the game was not ready to display it yet (I think because the room layout was not setup yet). This PR changes the relics to be added upon PostCreateStartingRelics, which does not trigger the tutorial popup, fixing the crash. As far as I know, there are no other issues with the mod's 2.0 compatibility. I have tested it and it works in my game.